### PR TITLE
Add DreamForge enhanced idea generator with CLI, web UI, JSON export, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# DreamForge（增强版）
+
+DreamForge 现在包含：
+
+- CLI 创意生成器
+- 技术栈推荐
+- 商业模式建议
+- MVP 路线图自动生成
+- Web 可视化点子卡片
+
+## CLI 用法
+
+```bash
+python3 dreamforge.py
+python3 dreamforge.py --seed 42
+python3 dreamforge.py --json
+python3 dreamforge.py --seed 42 --save ideas/today.json
+```
+
+## Web 可视化版
+
+```bash
+python3 web_app.py --host 127.0.0.1 --port 8000
+# 浏览器打开 http://127.0.0.1:8000
+```
+
+页面会生成一张包含「领域、目标用户、问题、玩法、亮点、技术栈、商业模式、MVP 路线图」的卡片。
+
+## 测试
+
+```bash
+python3 -m pytest -q
+```

--- a/dreamforge.py
+++ b/dreamforge.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""DreamForge: 创意软件点子锻造器（增强版）。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import random
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+ADJECTIVES = ["量子", "赛博", "像素", "梦境", "流光", "星尘", "荒野", "秘境"]
+PRODUCTS = ["笔记", "画布", "地图", "信使", "实验室", "工作台", "图鉴", "播客"]
+DOMAINS = ["学习", "健康", "创作", "游戏", "效率", "旅行", "社交", "理财"]
+MECHANICS = [
+    "用 AI 做每日挑战",
+    "把复杂任务拆成 3 分钟微步骤",
+    "通过故事化叙事引导用户坚持",
+    "让朋友互相协作打卡",
+    "根据情绪推荐不同模式",
+    "利用语音快速记录灵感",
+    "把数据转成可视化成长轨迹",
+    "每周自动生成复盘报告",
+]
+TWISTS = [
+    "它的核心界面像一款 RPG 游戏",
+    "所有操作都可以离线完成",
+    "每次打开都会出现一个随机创意任务",
+    "用户可以交易自己的模板与工作流",
+    "系统会把失败案例也当作奖励资源",
+    "支持把成果一键发布到社交平台",
+    "新人模式只有一个按钮，极简上手",
+    "可通过番茄钟 + 音乐进入心流",
+]
+PROBLEMS = [
+    "用户很难长期坚持好习惯",
+    "信息太多导致执行瘫痪",
+    "创意记录分散且难回顾",
+    "团队协作缺乏轻量流程",
+    "个人成长无法被量化追踪",
+]
+TARGET_USERS = ["学生", "独立开发者", "产品经理", "内容创作者", "远程团队", "自由职业者"]
+
+TECH_STACKS = {
+    "学习": ["Next.js", "FastAPI", "PostgreSQL", "Redis", "OpenAI API"],
+    "健康": ["Flutter", "FastAPI", "TimescaleDB", "Apple HealthKit", "Grafana"],
+    "创作": ["React", "Node.js", "Supabase", "Cloudflare R2", "FFmpeg"],
+    "游戏": ["Unity", "C#", "Firebase", "PlayFab", "Photon"],
+    "效率": ["Tauri", "Rust", "SQLite", "Actix Web", "WebSocket"],
+    "旅行": ["Vue", "Go", "PostGIS", "Mapbox", "Stripe"],
+    "社交": ["React Native", "NestJS", "MongoDB", "Socket.IO", "S3"],
+    "理财": ["SvelteKit", "Django", "PostgreSQL", "Plaid", "Docker"],
+}
+
+BUSINESS_MODELS = {
+    "学习": "Freemium + 订阅（高级题库与 AI 导师）",
+    "健康": "会员订阅 + 企业健康计划 B2B",
+    "创作": "模板市场抽佣 + Pro 订阅",
+    "游戏": "季票制 + 装扮内购",
+    "效率": "个人订阅 + 团队席位制收费",
+    "旅行": "交易佣金 + 增值服务包",
+    "社交": "创作者分成 + 品牌合作",
+    "理财": "高级分析订阅 + 顾问服务",
+}
+
+MVP_TEMPLATES = [
+    "第 1 周：完成用户访谈 10 人，验证核心痛点。",
+    "第 2 周：上线可交互原型，覆盖最小主流程。",
+    "第 3 周：接入关键数据追踪，观察激活与留存。",
+    "第 4 周：开放 50 位种子用户，基于反馈迭代。",
+]
+
+
+@dataclass
+class Idea:
+    name: str
+    domain: str
+    problem: str
+    target_user: str
+    premise: str
+    twist: str
+    tech_stack: list[str]
+    business_model: str
+    mvp_roadmap: list[str]
+
+    def pitch(self) -> str:
+        roadmap = "\n".join(f"  - {step}" for step in self.mvp_roadmap)
+        stack = " / ".join(self.tech_stack)
+        return (
+            f"【{self.name}】\n"
+            f"领域：{self.domain}\n"
+            f"目标用户：{self.target_user}\n"
+            f"要解决的问题：{self.problem}\n"
+            f"核心玩法：{self.premise}。\n"
+            f"亮点：{self.twist}。\n"
+            f"技术栈推荐：{stack}\n"
+            f"商业模式建议：{self.business_model}\n"
+            f"MVP 路线图：\n{roadmap}"
+        )
+
+
+class DreamForge:
+    def __init__(self, seed: int | None = None) -> None:
+        self._rng = random.Random(seed)
+
+    def generate(self) -> Idea:
+        domain = self._pick(DOMAINS)
+        return Idea(
+            name=f"{self._pick(ADJECTIVES)}{self._pick(PRODUCTS)}",
+            domain=domain,
+            problem=self._pick(PROBLEMS),
+            target_user=self._pick(TARGET_USERS),
+            premise=self._pick(MECHANICS),
+            twist=self._pick(TWISTS),
+            tech_stack=self._recommend_stack(domain),
+            business_model=BUSINESS_MODELS[domain],
+            mvp_roadmap=self._build_mvp_roadmap(),
+        )
+
+    def _pick(self, source: Iterable[str]) -> str:
+        return self._rng.choice(list(source))
+
+    def _recommend_stack(self, domain: str) -> list[str]:
+        stack = TECH_STACKS[domain][:]
+        self._rng.shuffle(stack)
+        return stack[:4]
+
+    def _build_mvp_roadmap(self) -> list[str]:
+        steps = MVP_TEMPLATES[:]
+        self._rng.shuffle(steps)
+        return steps
+
+
+def serialize_idea(idea: Idea) -> dict:
+    payload = asdict(idea)
+    payload["pitch"] = idea.pitch()
+    return payload
+
+
+def save_idea(idea: Idea, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(serialize_idea(idea), ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="DreamForge - 随机生成可执行的软件创意")
+    parser.add_argument("--seed", type=int, default=None, help="随机种子，便于复现结果")
+    parser.add_argument("--save", type=Path, default=None, help="把创意保存为 JSON 文件")
+    parser.add_argument("--json", action="store_true", help="以 JSON 直接打印到终端")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    idea = DreamForge(seed=args.seed).generate()
+
+    if args.json:
+        print(json.dumps(serialize_idea(idea), ensure_ascii=False, indent=2))
+    else:
+        print("✨ DreamForge 创意已出炉（增强版）！\n")
+        print(idea.pitch())
+
+    if args.save:
+        save_idea(idea, args.save)
+        print(f"\n💾 已保存到: {args.save}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_dreamforge.py
+++ b/test_dreamforge.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+from dreamforge import DreamForge, Idea, serialize_idea, save_idea
+
+
+def test_seeded_generation_is_deterministic() -> None:
+    assert DreamForge(seed=7).generate() == DreamForge(seed=7).generate()
+
+
+def test_pitch_contains_strategy_fields() -> None:
+    idea = Idea(
+        name="赛博画布",
+        domain="创作",
+        problem="创意记录分散且难回顾",
+        target_user="内容创作者",
+        premise="通过故事化叙事引导用户坚持",
+        twist="所有操作都可以离线完成",
+        tech_stack=["React", "Node.js", "Supabase", "FFmpeg"],
+        business_model="模板市场抽佣 + Pro 订阅",
+        mvp_roadmap=["第 1 周", "第 2 周", "第 3 周", "第 4 周"],
+    )
+    pitch = idea.pitch()
+    assert "技术栈推荐" in pitch
+    assert "商业模式建议" in pitch
+    assert "MVP 路线图" in pitch
+
+
+def test_save_and_serialize_include_enhanced_fields(tmp_path: Path) -> None:
+    idea = DreamForge(seed=3).generate()
+    payload = serialize_idea(idea)
+    assert isinstance(payload["tech_stack"], list)
+    assert payload["business_model"]
+    assert len(payload["mvp_roadmap"]) == 4
+
+    target = tmp_path / "idea.json"
+    save_idea(idea, target)
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["name"] == payload["name"]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>DreamForge Web</title>
+    <style>
+      body {
+        font-family: ui-sans-serif, system-ui, -apple-system, sans-serif;
+        background: #0b1020;
+        color: #e9edff;
+        margin: 0;
+      }
+      .wrap {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1rem 3rem;
+      }
+      h1 { margin-top: 0; }
+      .actions { display: flex; gap: 0.75rem; margin-bottom: 1rem; }
+      button {
+        border: 0;
+        background: #5a67ff;
+        color: #fff;
+        border-radius: 10px;
+        padding: 0.7rem 1rem;
+        cursor: pointer;
+      }
+      .card {
+        background: #161d36;
+        border: 1px solid #2a335f;
+        border-radius: 14px;
+        padding: 1rem;
+        line-height: 1.55;
+      }
+      .tag { display: inline-block; background: #2f3c73; padding: 0.25rem 0.55rem; border-radius: 999px; margin-right: 0.35rem; }
+      ol { margin-top: 0.35rem; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>✨ DreamForge Web 可视化版</h1>
+      <p>点击按钮，生成一张带「技术栈 + 商业模式 + MVP 路线图」的软件点子卡片。</p>
+      <div class="actions">
+        <button id="generate">生成新点子</button>
+      </div>
+      <div class="card" id="card">正在准备创意引擎...</div>
+    </div>
+
+    <script>
+      const card = document.getElementById("card");
+      async function loadIdea() {
+        card.innerHTML = "创意锻造中...";
+        const res = await fetch("/api/idea");
+        const idea = await res.json();
+        card.innerHTML = `
+          <h2>${idea.name}</h2>
+          <p><span class="tag">领域：${idea.domain}</span><span class="tag">用户：${idea.target_user}</span></p>
+          <p><strong>问题：</strong>${idea.problem}</p>
+          <p><strong>核心玩法：</strong>${idea.premise}</p>
+          <p><strong>亮点：</strong>${idea.twist}</p>
+          <p><strong>技术栈推荐：</strong>${idea.tech_stack.join(" / ")}</p>
+          <p><strong>商业模式建议：</strong>${idea.business_model}</p>
+          <strong>MVP 路线图：</strong>
+          <ol>${idea.mvp_roadmap.map((s) => `<li>${s}</li>`).join("")}</ol>
+        `;
+      }
+      document.getElementById("generate").addEventListener("click", loadIdea);
+      loadIdea();
+    </script>
+  </body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""DreamForge 本地 Web 服务。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from dreamforge import DreamForge, serialize_idea
+
+WEB_DIR = Path(__file__).parent / "web"
+
+
+class DreamForgeHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urlparse(self.path)
+
+        if parsed.path == "/api/idea":
+            self._handle_api_idea(parsed.query)
+            return
+
+        if parsed.path in {"/", "/index.html"}:
+            self._serve_file(WEB_DIR / "index.html", content_type="text/html; charset=utf-8")
+            return
+
+        self.send_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def _handle_api_idea(self, query: str) -> None:
+        params = parse_qs(query)
+        seed_value = params.get("seed", [None])[0]
+        seed = int(seed_value) if seed_value is not None else None
+
+        idea = DreamForge(seed=seed).generate()
+        body = json.dumps(serialize_idea(idea), ensure_ascii=False).encode("utf-8")
+
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _serve_file(self, file_path: Path, *, content_type: str) -> None:
+        if not file_path.exists():
+            self.send_error(HTTPStatus.NOT_FOUND, "Missing file")
+            return
+
+        body = file_path.read_bytes()
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="运行 DreamForge Web 可视化服务")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    server = ThreadingHTTPServer((args.host, args.port), DreamForgeHandler)
+    print(f"DreamForge Web running at http://{args.host}:{args.port}")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Provide an enhanced creative idea generator that outputs actionable product cards including technical stack recommendations, business model suggestions, and an MVP roadmap.
- Offer both a reproducible CLI workflow and a lightweight local web visualizer to make generation and sharing easy.

### Description

- Added `dreamforge.py` which implements an `Idea` dataclass, `DreamForge` generator with seeded randomness, `serialize_idea`, `save_idea`, and CLI flags `--seed`, `--json`, and `--save` for reproducible JSON output and file saving.
- Added `web_app.py` which serves a minimal HTTP server exposing `/api/idea` to return JSON ideas and serves the web UI. 
- Added a static web UI at `web/index.html` that fetches `/api/idea` and renders a card with domain, target user, problem, core mechanic, twist, tech stack, business model, and MVP roadmap. 
- Added `README.md` with usage instructions and `test_dreamforge.py` containing unit tests for deterministic generation, pitch content, and serialization/save behavior. 

### Testing

- Ran `python3 -m pytest -q` which executed the test suite in `test_dreamforge.py`. 
- All 3 tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c381a145c8832b9deeb9f9ad76522f)